### PR TITLE
3 | инициализация psql и pgadmi4 в docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+
+  db:
+    container_name: pg_db
+    image: postgres:16
+    env_file:
+      - .env
+    volumes:
+       - postgres:/data/postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - postgres
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER" ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  pgadmin:
+    container_name: pg_admin
+    image: dpage/pgadmin4
+    env_file:
+      - .env
+    ports:
+      - "5050:80"
+    networks:
+      - postgres
+    depends_on:
+      - db
+
+networks:
+  postgres:
+
+volumes:
+  postgres:


### PR DESCRIPTION
http://185.179.82.141/issues/3

В docker-compose реализована инициализация psql и админки для удобства.
Пример .env файла:
POSTGRES_USER=postgres
POSTGRES_PASSWORD=1234
POSTGRES_DB=app_db
POSTGRES_HOST=localhost
POSTGRES_PORT=5432

PGADMIN_DEFAULT_EMAIL=admin@example.com
PGADMIN_DEFAULT_PASSWORD=admin

Админка расположена по адресу http://localhost:5050/ для доступа к БД создать сервер и указать во вкладке соединение имя/адрес сервера, как имя контейнера с psql (pg_db).

Команда для запуска:
docker-compose up --build